### PR TITLE
Update manifest.json

### DIFF
--- a/3dvr-react-app/public/manifest.json
+++ b/3dvr-react-app/public/manifest.json
@@ -6,16 +6,6 @@
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
     }
   ],
   "start_url": ".",


### PR DESCRIPTION
Closing as stale operational cleanup. This 2023 manifest change only removes legacy CRA icons, and the PR has had no activity since Nov. 20, 2023. Keeping it open adds delivery noise without improving the current 3DVR stack. Reopen if this exact manifest change becomes relevant again.